### PR TITLE
Fixed an error when running chatbot.py on BMO/Linux

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from actions import action
 
 with open(".env", "r") as file:
-    api_key = file.read()
+    api_key = file.read().strip()
 
 client = OpenAI(api_key=api_key)
 


### PR DESCRIPTION
Running chatbot.py using `python chatbot.py` caused an "Illegal header value" error. Adding `.strip()` to `api_key = file.read()` fixes the issue.